### PR TITLE
Pulling set_fee tx updates

### DIFF
--- a/tests/unit/models/transactions/test_pseudo_transactions.py
+++ b/tests/unit/models/transactions/test_pseudo_transactions.py
@@ -37,7 +37,7 @@ class TestPseudoTransactions(TestCase):
         full_dict = {**amendment_dict, "Flags": 0, "TxnSignature": ""}
         self.assertEqual(actual.to_xrpl(), full_dict)
 
-    def test_from_xrpl_set_fee(self):
+    def test_from_xrpl_set_fee_pre_amendment(self):
         reference_fee_units = 10
         reserve_base = 20000000
         reserve_increment = 5000000
@@ -58,6 +58,30 @@ class TestPseudoTransactions(TestCase):
             reserve_base=reserve_base,
             reserve_increment=reserve_increment,
             base_fee=base_fee,
+        )
+        actual = Transaction.from_xrpl(set_fee_dict)
+        self.assertEqual(actual, expected)
+        full_dict = {**set_fee_dict, "Flags": 0, "TxnSignature": ""}
+        self.assertEqual(actual.to_xrpl(), full_dict)
+
+    def test_from_xrpl_set_fee_post_amendment(self):
+        reserve_base_drops = "20000000"
+        reserve_increment_drops = "5000000"
+        base_fee_drops = "000000000000000A"
+        set_fee_dict = {
+            "Account": "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+            "BaseFeeDrops": base_fee_drops,
+            "Fee": "0",
+            "ReserveBaseDrops": reserve_base_drops,
+            "ReserveIncrementDrops": reserve_increment_drops,
+            "Sequence": 0,
+            "SigningPubKey": "",
+            "TransactionType": "SetFee",
+        }
+        expected = SetFee(
+            reserve_base_drops=reserve_base_drops,
+            reserve_increment_drops=reserve_increment_drops,
+            base_fee_drops=base_fee_drops,
         )
         actual = Transaction.from_xrpl(set_fee_dict)
         self.assertEqual(actual, expected)

--- a/xrpl/models/transactions/pseudo_transactions/set_fee.py
+++ b/xrpl/models/transactions/pseudo_transactions/set_fee.py
@@ -1,9 +1,10 @@
 """Model for SetFee pseudo-transaction type."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Optional
 
-from xrpl.models.required import REQUIRED
 from xrpl.models.transactions.pseudo_transactions.pseudo_transaction import (
     PseudoTransaction,
 )
@@ -19,9 +20,24 @@ class SetFee(PseudoTransaction):
     <https://xrpl.org/transaction-cost.html>`_ or `reserve requirements
     <https://xrpl.org/reserves.html>`_ as a result of `Fee Voting
     <https://xrpl.org/fee-voting.html>`_.
+
+    The parameters are different depending on if this is before or after the
+    `XRPFees Amendment<https://xrpl.org/known-amendments.html#xrpfees>`_
+
+    Before the XRPFees Amendment which was proposed in rippled 1.10.0
+    base_fee, reference_fee_units, reserve_base, and reserve_increment
+    were required fields.
+
+    After the XRPFees Amendment, base_fee_drops, reserve_base_drops,
+    and reserve_increment_drops are required fields.
+
+    No SetFee Pseudo Transaction should contain fields from BOTH before
+    and after the XRPFees amendment.
     """
 
-    base_fee: str = REQUIRED  # type: ignore
+    # Required BEFORE the XRPFees Amendment
+
+    base_fee: Optional[str] = None
     """
     The charge, in drops of XRP, for the reference transaction, as hex. (This is the
     transaction cost before scaling for load.) This field is required.
@@ -29,32 +45,49 @@ class SetFee(PseudoTransaction):
     :meta hide-value:
     """
 
-    reference_fee_units: int = REQUIRED  # type: ignore
+    reference_fee_units: Optional[int] = None
     """
     The cost, in fee units, of the reference transaction. This field is required.
 
     :meta hide-value:
     """
 
-    reserve_base: int = REQUIRED  # type: ignore
+    reserve_base: Optional[int] = None
     """
     The base reserve, in drops. This field is required.
 
     :meta hide-value:
     """
 
-    reserve_increment: int = REQUIRED  # type: ignore
+    reserve_increment: Optional[int] = None
     """
     The incremental reserve, in drops. This field is required.
 
     :meta hide-value:
     """
 
-    ledger_sequence: Optional[int] = None
+    # Required AFTER the XRPFees Amendment
+
+    base_fee_drops: Optional[str] = None
     """
-    The index of the ledger version where this pseudo-transaction appears. This
-    distinguishes the pseudo-transaction from other occurrences of the same change.
-    This field is omitted for some historical SetFee pseudo-transactions.
+    The charge, in drops of XRP, for the reference transaction, as hex. (This is the
+    transaction cost before scaling for load.) This field is required.
+
+    :meta hide-value:
+    """
+
+    reserve_base_drops: Optional[str] = None
+    """
+    The base reserve, in drops. This field is required.
+
+    :meta hide-value:
+    """
+
+    reserve_increment_drops: Optional[str] = None
+    """
+    The incremental reserve, in drops. This field is required.
+
+    :meta hide-value:
     """
 
     transaction_type: PseudoTransactionType = field(


### PR DESCRIPTION
https://github.com/XRPLF/xrpl-py/commit/a1e7ec59d748d32ced8652a00edea6010d5a3efe

# Testing
Tested locally with broken block `92508417`

## Before:
<img width="891" alt="Screenshot 2024-12-02 at 4 45 21 PM" src="https://github.com/user-attachments/assets/feea9085-4eca-4053-8c27-184f44ba9fa0">

## After:

<img width="778" alt="Screenshot 2024-12-02 at 4 45 33 PM" src="https://github.com/user-attachments/assets/60129789-4904-45db-bfcd-b12561c2d25d">
