### PR TITLE
Add default value of NULL for optional fields

### DIFF
--- a/xrpl/models/base_model.py
+++ b/xrpl/models/base_model.py
@@ -358,7 +358,6 @@ class BaseModel(ABC):
         return {
             key: self._to_dict_elem_no_nesting(getattr(self, key))
             for key in dataclass_fields
-            if getattr(self, key) is not None
         }
 
     def _to_dict_elem_no_nesting(self: BaseModel, elem: Any) -> Any:


### PR DESCRIPTION
## Description
- Optional fields that have NULL values were originaly removed from the resulting json file. This lead to failures downstream in the json to parquert conversion as the conversion inferes the schema and if it doesn't find a field it would error out
- This PR makes sure all fields are added even if they have NULL values

## Testing
All green ripple export 
![image](https://github.com/user-attachments/assets/af5ae2ea-f7e5-4a26-8ad5-e8338e7b99cb)
