### PR TITLE
Add nft token metadata

### DIFF
--- a/xrpl/core/binarycodec/definitions/definitions.json
+++ b/xrpl/core/binarycodec/definitions/definitions.json
@@ -2568,6 +2568,7 @@
     "AccountDelete": 21,
     "SetHook": 22,
     "NFTokenMint": 25,
+    "NFTokenModify": 61,
     "NFTokenBurn": 26,
     "NFTokenCreateOffer": 27,
     "NFTokenCancelOffer": 28,

--- a/xrpl/models/base_model.py
+++ b/xrpl/models/base_model.py
@@ -128,7 +128,7 @@ class BaseModel(ABC):
         for param in value:
             if param not in class_types:
                 # Do not fail parsing if we encounter an unknown arg
-                logging.warn(
+                logging.debug(
                     f"{param} not a valid parameter for {cls.__name__}"
                 )
                 continue

--- a/xrpl/models/transactions/__init__.py
+++ b/xrpl/models/transactions/__init__.py
@@ -48,6 +48,7 @@ from xrpl.models.transactions.nftoken_mint import (
     NFTokenMintFlag,
     NFTokenMintFlagInterface,
 )
+from xrpl.models.transactions.nftoken_modify import NFTokenModify
 from xrpl.models.transactions.offer_cancel import OfferCancel
 from xrpl.models.transactions.offer_create import (
     OfferCreate,
@@ -129,6 +130,7 @@ __all__ = [
     "NFTokenMint",
     "NFTokenMintFlag",
     "NFTokenMintFlagInterface",
+    "NFTokenModify",
     "OfferCancel",
     "OfferCreate",
     "OfferCreateFlag",

--- a/xrpl/models/transactions/nftoken_modify.py
+++ b/xrpl/models/transactions/nftoken_modify.py
@@ -1,0 +1,72 @@
+"""Model for NFTokenModify transaction type."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from typing_extensions import Final, Self
+
+from xrpl.models.required import REQUIRED
+from xrpl.models.transactions.transaction import Transaction
+from xrpl.models.transactions.types import TransactionType
+from xrpl.models.utils import HEX_REGEX, KW_ONLY_DATACLASS, require_kwargs_on_init
+
+_MAX_URI_LENGTH: Final[int] = 512
+
+
+@require_kwargs_on_init
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class NFTokenModify(Transaction):
+    """
+    The NFTokenModify transaction modifies an NFToken's URI
+    if its tfMutable is set to true.
+    """
+
+    nftoken_id: str = REQUIRED  # type: ignore
+    """
+    Identifies the TokenID of the NFToken object that the
+    offer references. This field is required.
+    """
+
+    owner: Optional[str] = None
+    """
+    Indicates the AccountID of the account that owns the
+    corresponding NFToken.
+    """
+
+    uri: Optional[str] = None
+    """
+    URI that points to the data and/or metadata associated with the NFT.
+    This field need not be an HTTP or HTTPS URL; it could be an IPFS URI, a
+    magnet link, immediate data encoded as an RFC2379 "data" URL, or even an
+    opaque issuer-specific encoding. The URI is not checked for validity.
+
+    This field must be hex-encoded. You can use `xrpl.utils.str_to_hex` to
+    convert a UTF-8 string to hex.
+    """
+
+    transaction_type: TransactionType = field(
+        default=TransactionType.NFTOKEN_MODIFY,
+        init=False,
+    )
+
+    def _get_errors(self: Self) -> Dict[str, str]:
+        return {
+            key: value
+            for key, value in {
+                **super()._get_errors(),
+                "uri": self._get_uri_error(),
+            }.items()
+            if value is not None
+        }
+
+    def _get_uri_error(self: Self) -> Optional[str]:
+        if not self.uri:
+            return "URI must not be empty string"
+        elif len(self.uri) > _MAX_URI_LENGTH:
+            return f"URI must not be longer than {_MAX_URI_LENGTH} characters"
+
+        if not HEX_REGEX.fullmatch(self.uri):
+            return "URI must be encoded in hex"
+        return None

--- a/xrpl/models/transactions/types/transaction_type.py
+++ b/xrpl/models/transactions/types/transaction_type.py
@@ -37,6 +37,7 @@ class TransactionType(str, Enum):
     PAYMENT_CHANNEL_CLAIM = "PaymentChannelClaim"
     PAYMENT_CHANNEL_CREATE = "PaymentChannelCreate"
     PAYMENT_CHANNEL_FUND = "PaymentChannelFund"
+    NFTOKEN_MODIFY = "NFTokenModify"
     SET_REGULAR_KEY = "SetRegularKey"
     SIGNER_LIST_SET = "SignerListSet"
     TICKET_CREATE = "TicketCreate"

--- a/xrpl/models/utils.py
+++ b/xrpl/models/utils.py
@@ -1,8 +1,14 @@
 """Helper util functions for the models module."""
+import re
 from dataclasses import dataclass, is_dataclass
-from typing import Any, Dict, List, Type, TypeVar, cast
+from typing import Any, Dict, List, Optional, Pattern, Type, TypeVar, cast
+
+from typing_extensions import Final
 
 from xrpl.models.exceptions import XRPLModelException
+
+HEX_REGEX: Final[Pattern[str]] = re.compile("[a-fA-F0-9]*")
+
 
 # Code source for requiring kwargs:
 # https://gist.github.com/mikeholler/4be180627d3f8fceb55704b729464adb


### PR DESCRIPTION
## Description
- Add a new transaction type NFTokenMetadata from the parent repo. https://github.com/XRPLF/xrpl-py/pull/799/files
- Use debug instead of warn for missing fields

## Testing
- Locally using the block containing this transaction type `96729412`